### PR TITLE
fixed style build error

### DIFF
--- a/lib/svg-icon.vue
+++ b/lib/svg-icon.vue
@@ -65,7 +65,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 svg {
 	transform: rotate(var(--r, 0deg)) scale(var(--sx, 1), var(--sy, 1));
 }


### PR DESCRIPTION
Can we add `lang="scss"` into `<style>`? 
While compiling my code with vue-icon, I failed with this error message.
```
You may need an additional loader to handle the result of these loaders.
|
> svg {
| 	transform: rotate(var(--r, 0deg)) scale(var(--sx, 1), var(--sy, 1));
| }
```