### PR TITLE
Add a TypeScript definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,15 @@
+declare module '@jamescoyle/vue-icon' {
+  import { DefineComponent } from 'vue';
+
+  interface SvgIconProps {
+    type?: string;
+    path: string;
+    size?: string | number;
+    viewbox?: string;
+    flip?: 'horizontal' | 'vertical' | 'both' | 'none';
+    rotate?: number;
+  }
+
+  const SvgIcon: DefineComponent<SvgIconProps>;
+  export default SvgIcon;
+}


### PR DESCRIPTION
The module doesn't have a TypeScript definition, as such, fails to import without error or warning (depending on the project configuration) when use within TypeScript projects. All that's missing is a definition file like this.